### PR TITLE
Answering: What if a literal has no datatype?

### DIFF
--- a/interface-spec.md
+++ b/interface-spec.md
@@ -57,10 +57,11 @@ TODO: Does the value always start with an underscore?
 
 - `String .termType` contains the constant `"literal"`.
 - `String .value` the text value, unescaped, without language or type (example: `Brad Pitt`)
-- `String .language` the language as lowercase [BCP47](http://tools.ietf.org/html/bcp47) string (examples: `en`, `en-gb`)
+- `String .language` the language as lowercase [BCP47](http://tools.ietf.org/html/bcp47) string (examples: `en`, `en-gb`) or an empty string if the literal has no language.
 - `IRI .datatype` the datatype of the literal
 
-TODO: What if the literal has no language? Does it always have a datatype?
+If the literal has a language, the datatype IRI is `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString`.
+Otherwise, if no datatype is explicitly specified, the datatype IRI is `http://www.w3.org/2001/XMLSchema#string`.
 
 ### Variable extends Term
 

--- a/interface-spec.md
+++ b/interface-spec.md
@@ -58,7 +58,7 @@ TODO: Does the value always start with an underscore?
 - `String .termType` contains the constant `"literal"`.
 - `String .value` the text value, unescaped, without language or type (example: `Brad Pitt`)
 - `String .language` the language as lowercase [BCP47](http://tools.ietf.org/html/bcp47) string (examples: `en`, `en-gb`)
-- `String .datatype` the datatype IRI as string
+- `IRI .datatype` the datatype of the literal
 
 TODO: What if the literal has no language? Does it always have a datatype?
 
@@ -97,7 +97,7 @@ TODO: Do we need to define a different interface, or is a quad simply a triple w
 
 - `.iri(String iri)` returns a new instance of IRI.
 - `.blankNode()` returns a new instance of BlankNode.
-- `.literal(String value, String language, String datatype)` returns a new instance of Literal.
+- `.literal(String value, String language, String|IRI datatype)` returns a new instance of Literal.
 - `.variable(String name)` returns a new instance of Variable. This method is optional.
 - `.triple([Object])` returns a new instance of Triple. 
 - `.quad([Object])` returns a new instance of Quad.
@@ -105,8 +105,6 @@ TODO: Do we need to define a different interface, or is a quad simply a triple w
 TODO: `.blankNode()` could/should have an optional suggested label.
 
 TODO: `.literal()` could have a more intelligent constructor (valid language strings are not valid IRIs and vice-versa).
-
-TODO: `.literal()` should support IRI datatype as well
 
 TODO: Can/should `.literal()` accept built-in types like integers?
 


### PR DESCRIPTION
Answer to the following TODO in the spec: "Does [a literal] always have a datatype?"

**Semantically** speaking, a literal always has a datatype IRI.  Therefore, a function `.datatype` should return a datatype IRI for *every* literal.

**Syntactically** speaking, certain serialization formats allow abbreviations in which the datatype can be left implicit.  These abbreviations should all and only be handled by the parser.  The result of the parser should not show whether or not an abbreviated form was used in the input serialization.  For instance, the result of parsing `"01"` should be the same as the result of parsing `"01"^^xsd:int` (assuming the Turtle 1.1 grammar).  Specifically, once a JS datastructure, both should return `xsd:int` as the result of `.datatype`.

Syntactic abbreviations are (at least) use in Turtle 1.1 (and the formats based on that, i.e., N-Quads, N-Triples, TriG), where the following lexical expressions are auto-assigned a datatype IRI:
  1. A literal expression that parses as `INTEGER` has datatype `xsd:integer`.
  2. A literal expression that parses as `DECIMAL` has datatype `xsd:decimal`.
  3. A literal expression that parses as `BooleanLiteral` has datatype `xsd:boolean`.
  4. A literal expression that parses as `DOUBLE` has datatype `xsd:double`.
  5. A literal expression that parses as `String LANGTAG` has datatype `rdf:langString`.
  6. All other literal expressions parse as `String '^^' iri` and have the datatype denoted by `iri`.

The relevant Turtle 1.1 grammar rules are included for reference:
```
[13] 	literal 	::= 	RDFLiteral | NumericLiteral | BooleanLiteral
[16] 	NumericLiteral 	::= 	INTEGER | DECIMAL | DOUBLE
[128s] 	RDFLiteral 	::= 	String (LANGTAG | '^^' iri)?
[133s] 	BooleanLiteral 	::= 	'true' | 'false'
[144s] 	LANGTAG 	::= 	'@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*
[19] 	INTEGER 	::= 	[+-]? [0-9]+
[20] 	DECIMAL 	::= 	[+-]? [0-9]* '.' [0-9]+
[21] 	DOUBLE 	::= 	[+-]? ([0-9]+ '.' [0-9]* EXPONENT | '.' [0-9]+ EXPONENT | [0-9]+ EXPONENT)
[154s] 	EXPONENT 	::= 	[eE] [+-]? [0-9]+
```

Notice that there may be other abbreviations defined by other serialization formats.  E.g., JSON-LD allows datatypes to be specified in the context.  For these formats the same distinction between syntax (possibly allowing abbreviations) and semantics (a uniform API for literals, always returning a result for `.datatype`) should be maintained.

*[Updated based on feedback from @RubenVerborgh]*