### PR TITLE
Triple factory shouldn't accept graph name

### DIFF
--- a/interface-spec.md
+++ b/interface-spec.md
@@ -115,5 +115,5 @@ Triples always have `.graph` set to DefaultGraph.
 - `Literal .literal(String value, String language, String datatype)` returns a new instance of Literal.
 - `Variable .variable(String name)` returns a new instance of Variable. This method is optional.
 - `DefaultGraph .defaultGraph()` returns an instance of DefaultGraph.
-- `Triple .triple(Term subject, Term predicate, Term object, [Term graph])` returns a new instance of Triple.
+- `Triple .triple(Term subject, Term predicate, Term object)` returns a new instance of Triple.
 - `Quad .quad(Term subject, Term predicate, Term object, [Term graph])` returns a new instance of Quad.


### PR DESCRIPTION
> Triple is an alias of Quad. Triples always have .graph set to DefaultGraph
&mdash; https://github.com/rdfjs/representation-task-force/blob/master/interface-spec.md#triple

Since Triple has always .graph set to DefaultGraph, it doesn't make sense to allow graph as an optional parameter in factory.