### PR TITLE
Rename .termType to .valueType

### DIFF
--- a/interface-spec.md
+++ b/interface-spec.md
@@ -15,7 +15,7 @@ This document provides a specification of a low level interface definition repre
 - Given the necessity of methods, plain objects (JSON) cannot be used.
 - Factory functions (e.g., `quad()`) or methods (e.g., `store.createQuad()`) create instances.
   - Should allow "upgrading" a plain object into a fully functional triple
-- Interfaces may have additional implementation specific properties. 
+- Interfaces may have additional implementation specific properties.
   A list of these properties maintained on the [RDFJS Representation Task Force wiki](https://github.com/rdfjs/representation-task-force/wiki/Additional-properties).
 
 ## Data interfaces
@@ -27,8 +27,10 @@ This document provides a specification of a low level interface definition repre
 Abstract interface.
 
 **Properties:**
-- `String .termType` contains a value that identifies the concrete interface of the term, since Term itself is not directly instantiated.
-  Possible values include `"iri"`, `"bnode"`, `"literal"`, and `"variable"`.
+- `String .valueType` identifies the concrete type of the term value (and
+  therefore identifies the interface of the term, since Term itself is not
+  directly instantiated). Possible values include: `"iri"`, `"bnode"`,
+  `"literal"`, and `"variable"`.
 - `String .value` is refined by each interface which extends Term
 
 **Methods:**
@@ -42,21 +44,21 @@ Abstract interface.
 
 **Properties:**
 
-- `String .termType` contains the constant `"iri"`.
+- `String .valueType` contains the constant `"iri"`.
 - `String .value` the IRI as a string (example: `http://example.org/resource`)
 
 ### BlankNode extends Term
 
 **Properties:**
 
-- `String .termType` contains the constant `"bnode"`.
+- `String .valueType` contains the constant `"bnode"`.
 - `String .value` blank node name as a string, without any serialization specific prefixes, e.g. when parsing, if the data was sourced from Turtle, remove _:, if it was sourced from RDF/XML, do not change the blank node name (example: `blank3`)
 
 ### Literal extends Term
 
 **Properties:**
 
-- `String .termType` contains the constant `"literal"`.
+- `String .valueType` contains the constant `"literal"`.
 - `String .value` the text value, unescaped, without language or type (example: `Brad Pitt`)
 - `String .language` the language as lowercase [BCP47](http://tools.ietf.org/html/bcp47) string (examples: `en`, `en-gb`) or an empty string if the literal has no language.
 - `IRI .datatype` the datatype of the literal
@@ -68,17 +70,17 @@ Otherwise, if no datatype is explicitly specified, the datatype IRI is `http://w
 
 **Properties:**
 
-- `String .termType` contains the constant `"variable"`.
+- `String .valueType` contains the constant `"variable"`.
 - `String .value` the name of the variable without leading `?` (example: `a`)
 
 ### DefaultGraph extends Term
 
 An instance of `DefaultGraph` represents the default graph.
-It's only allowed to assign a `DefaultGraph` to the `.graph` property of a `Quad`. 
+It's only allowed to assign a `DefaultGraph` to the `.graph` property of a `Quad`.
 
 **Properties:**
 
-- `String .termType` contains the constant `"defaultGraph"`.
+- `String .valueType` contains the constant `"defaultGraph"`.
 - `String .value` contains an empty string as constant value.
 
 ### Triple


### PR DESCRIPTION
Per @bergos - The Term can be seen as a container. `.termType` would
mean the type of the Term, so the interface name/type. But it
describes the type of the value ("iri", "bnode", "literal", and
"variable"). We had a very long discussion about these values. So
let's keep these values and rename `.termType` to `.valueType`. Than
it would describe the type of the value the container holds.