### PR TITLE
Remove toCanonical()

### DIFF
--- a/interface-spec.md
+++ b/interface-spec.md
@@ -95,8 +95,6 @@ Triple is an alias of Quad.
 - `Term .object` the object, which is an IRI, a Literal, a BlankNode or Variable.
 - `Term .graph` the named graph, which is an IRI, DefaultGraph, BlankNode or Variable.
 
-- `Boolean .equals(Quad other)` returns true if and only if the argument is a) of the same type b) has all components equal
-
 **Methods:**
 
 - `string .toCanonical()` returns a canonical string representation of the quad.

--- a/interface-spec.md
+++ b/interface-spec.md
@@ -34,10 +34,6 @@ Abstract interface.
 **Methods:**
 
 - `boolean .equals(Term other)` returns true if and only if the argument is a) of the same type b) has the same contents (value and, if applicable, type or language)
-- `string .toCanonical()` returns a canonical string representation of the term.
-  For IRIs, BlankNodes and Literals the [N-Triples canonical form](https://www.w3.org/TR/n-triples/#canonical-ntriples) must be used.
-  Variables must return the variable name prefixed with a question mark (example: `?a`).
-  DefaultGraph must return an empty string.
 
 ### NamedNode extends Term
 
@@ -97,13 +93,7 @@ Triple is an alias of Quad.
 
 **Methods:**
 
-- `string .toCanonical()` returns a canonical string representation of the quad.
-  The [N-Triples canonical form](https://www.w3.org/TR/n-triples/#canonical-ntriples) must be used.
-  Terms must be represented as defined in the `.toCanonical()` method of the Term interface.
 - `boolean .equals(Quad other)` returns true if and only if the argument is a) of the same type b) has all components equal
-  Quads that contain a non-default graph must add the graph as defined in the [N-Quads specification](https://www.w3.org/TR/n-quads/).
-  For that use case the definition of [N-Triples canonical form](https://www.w3.org/TR/n-triples/#canonical-ntriples) is extended:
-  the whitespace following subject, predicate, object and graph MUST be a single space, (U+0020).
 
 ### DataFactory
 


### PR DESCRIPTION
I propose to remove `toCanonical`, since there is currently no inherent need to have it. It is not necessary for equality comparisons at the moment (#88, #53). The current definition is too expensive for repeated use, for instance for keying (#89).

Furthermore, `toCanonical` is not a "core" property of a triple/quad/term like _subject_, _predicate_, _object_, _value_, _datatype_, _language_, _termType_ are. So we should really wonder whether it makes sense to require all implementers to have it.

Libraries can implement their own `toCanonical`, `toString`, or any other display method; there is no need to agree on it (and as such, it shouldn't be part of the spec).

So unless we really can identify an added value for having a cross-implementation `toCanonical`, the more logical thing might be to simply remove it.