### PR TITLE
remove plain objects

### DIFF
--- a/interface-spec.html
+++ b/interface-spec.html
@@ -99,12 +99,10 @@
     <li>Instances of the interfaces created with different libraries should be interoperable.</li>
     <li>Interfaces do <em>not</em> specify how instances are stored in memory.</li>
     <li>Interfaces mandate specific pre-defined methods such as <code>.equals()</code>.</li>
-    <li>Given the necessity of methods, plain objects (JSON) cannot be used.</li>
     <li>
       Factory functions (e.g., <code>quad()</code>) or methods (e.g.,
       <code>store.createQuad()</code>) create instances.
     </li>
-    <li>Should allow "upgrading" a plain object into a fully functional triple</li>
     <li>Interfaces may have additional implementation specific properties.</li>
   </ul>
 


### PR DESCRIPTION
This PR removes leftovers from the plain objects idea as proposed in #104. Initial there was the idea to have plain objects without any functions for `Term` and `Quad`, but it never made it into the spec and based on some experience using implementations without plain objects, the lack of this feature doesn't cause any problems. But adding plain objects to the spec could cause a lot of problems:

- It would add much more complexity
  - Seven additional interfaces would be required (Term + subclasses, Quad)
  - Other interfaces would get more complex as they may or may not support these new interfaces
- It opens the door for a new serialization
  - People my start passing it around as JSON strings
  - Forces others to support an additional format
  - Media Type
  - ...
- JSON-LD is an existing standard for JSON + plain objects
  - flattened Quads are easy to write and parse
- It doesn't forbid the usage of plain objects for internal structures